### PR TITLE
Set locale to C.UTF8 (fixes issue #2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,6 @@ VOLUME /comics
 
 EXPOSE 8080
 
+ENV LC_ALL=C.UTF8
+
 ENTRYPOINT ["YACReaderLibraryServer","start"]


### PR DESCRIPTION
This PR sets the containers default locale from POSIX (aka ascii) to a neutral UTF8 locale.

In my tests this fixed the issues with special characters in file names users were reporting (see issue #2).