### PR TITLE
Updated at version 9.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cd /     && \
     apt-get -y autoremove
 ADD YACReaderLibrary.ini /root/.local/share/YACReader/YACReaderLibrary/
 
-VOLUME /comics
+VOLUME /config /comics
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd compressed_archive/unarr/ && \
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
 RUN cd /src/git/YACReaderLibraryServer && \
-    qmake CONFIG += 7zip YACReaderLibraryServer.pro && \
+    qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
     make  && \
     make install
 RUN cd /     && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR git
 # Update system
 #RUN add-apt-repository universe
 RUN apt-get update && \
-    apt-get -y install p7zip-full p7zip-rar git dumb-init qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
+    apt-get -y install p7zip-full git dumb-init qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
 RUN git clone https://github.com/YACReader/yacreader.git . && \
     git checkout 9.7.1
 RUN cd compressed_archive/unarr/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd compressed_archive/unarr/ && \
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
 RUN cd compressed_archive/ &&\
-    wget github.com/stonewell/lib7zip .
+    git clone https://github.com/stonewell/lib7zip .
 RUN cd /src/git/YACReaderLibraryServer && \
     qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
     make  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN cd /     && \
     apt-get -y autoremove
 ADD YACReaderLibrary.ini /root/.local/share/YACReader/YACReaderLibrary/
 
-ADD entrypoint.sh /
-RUN /bin/sh -c 'chmod +x /entrypoint.sh'
+#ADD entrypoint.sh /
+#RUN /bin/sh -c 'chmod +x /entrypoint.sh'
 
 # add specific volumes: configuration, comics repository, and hidden library data to separate them
 VOLUME ["/config", "/comics", "/comics/.yacreaderlibrary"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN cd compressed_archive/unarr/ && \
     rm master.zip &&\
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
+RUN cd compressed_archive/p7zip &&\
+    wget github.com/stonewell/lib7zip . &&\
 RUN cd /src/git/YACReaderLibraryServer && \
     qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
     make  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ WORKDIR git
 
 # Update system
 # Update system
+RUN add-apt-repository universe
 RUN apt-get update && \
-    apt-get -y install git dumb-init qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
+    apt-get -y install p7zip-full p7zip-rar git dumb-init qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
 RUN git clone https://github.com/YACReader/yacreader.git . && \
     git checkout 9.7.1
 RUN cd compressed_archive/unarr/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR git
 
 # Update system
 # Update system
-RUN add-apt-repository universe
+#RUN add-apt-repository universe
 RUN apt-get update && \
     apt-get -y install p7zip-full p7zip-rar git dumb-init qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
 RUN git clone https://github.com/YACReader/yacreader.git . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd compressed_archive/unarr/ && \
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
 RUN cd compressed_archive/ &&\
-    git clone https://github.com/stonewell/lib7zip ./lib7zip
+    git clone https://github.com/stonewell/lib7zip ./libp7zip
 RUN cd /src/git/YACReaderLibraryServer && \
     qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
     make  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR git
 RUN apt-get update && \
     apt-get -y install p7zip-full git dumb-init qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
 RUN git clone https://github.com/YACReader/yacreader.git . && \
-    git checkout 9.7.1
+    git checkout 9.8.0
 RUN cd compressed_archive/unarr/ && \
     wget github.com/selmf/unarr/archive/master.zip &&\
     unzip master.zip  &&\
@@ -20,7 +20,7 @@ RUN cd compressed_archive/unarr/ && \
 RUN cd compressed_archive/ &&\
     git clone https://github.com/btolab/p7zip ./libp7zip
 RUN cd /src/git/YACReaderLibraryServer && \
-    qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
+    qmake "CONFIG+=7zip server_standalone" YACReaderLibraryServer.pro && \
     make  && \
     make install
 RUN cd /     && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ WORKDIR /src
 WORKDIR git
 
 # Update system
+# Update system
 RUN apt-get update && \
-    apt-get -y install git qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
+    apt-get -y install git dumb-init qt5-default libpoppler-qt5-dev libpoppler-qt5-1 wget unzip libqt5sql5-sqlite libqt5sql5 sqlite3 libqt5network5 libqt5gui5 libqt5core5a build-essential
 RUN git clone https://github.com/YACReader/yacreader.git . && \
-    git checkout master
+    git checkout 9.7.1
 RUN cd compressed_archive/unarr/ && \
     wget github.com/selmf/unarr/archive/master.zip &&\
     unzip master.zip  &&\
@@ -25,6 +26,9 @@ RUN cd /     && \
     apt-get purge -y git wget build-essential && \
     apt-get -y autoremove
 ADD YACReaderLibrary.ini /root/.local/share/YACReader/YACReaderLibrary/
+
+ADD entrypoint.sh /
+RUN /bin/sh -c 'chmod +x /entrypoint.sh'
 
 # add specific volumes: configuration, comics repository, and hidden library data to separate them
 VOLUME ["/config", "/comics", "/comics/.yacreaderlibrary"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd compressed_archive/unarr/ && \
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
 RUN cd /src/git/YACReaderLibraryServer && \
-    qmake YACReaderLibraryServer.pro && \
+    qmake CONFIG += 7zip YACReaderLibraryServer.pro && \
     make  && \
     make install
 RUN cd /     && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN cd /     && \
     apt-get -y autoremove
 ADD YACReaderLibrary.ini /root/.local/share/YACReader/YACReaderLibrary/
 
-VOLUME /config /comics
+# add specific volumes: configuration, comics repository, and hidden library data to separate them
+VOLUME ["/config", "/comics", "/comics/.yacreaderlibrary"]
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd compressed_archive/unarr/ && \
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
 RUN cd compressed_archive/ &&\
-    git clone https://github.com/stonewell/lib7zip .
+    git clone https://github.com/stonewell/lib7zip ./lib7zip
 RUN cd /src/git/YACReaderLibraryServer && \
     qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
     make  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd compressed_archive/unarr/ && \
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
 RUN cd compressed_archive/ &&\
-    git clone https://github.com/stonewell/lib7zip ./libp7zip
+    git clone https://github.com/btolab/p7zip ./libp7zip
 RUN cd /src/git/YACReaderLibraryServer && \
     qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
     make  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN cd compressed_archive/unarr/ && \
     rm master.zip &&\
     cd unarr-master/lzmasdk &&\
     ln -s 7zTypes.h Types.h
-RUN cd compressed_archive/p7zip &&\
-    wget github.com/stonewell/lib7zip . &&\
+RUN cd compressed_archive/ &&\
+    wget github.com/stonewell/lib7zip .
 RUN cd /src/git/YACReaderLibraryServer && \
     qmake "CONFIG+=7zip" YACReaderLibraryServer.pro && \
     make  && \


### PR DESCRIPTION
- Updated the compilation using the last stable version
- Compiled against proper 7zip library to get rid of the 7z error message when creating a new library
- Explicitly referenced the `.yacreaderlibrary` folder to let the user mount it outside the comics folder