### PR TITLE
docker multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,5 @@ VOLUME ["/comics"]
 EXPOSE 8080
 
 ENV LC_ALL=C.UTF8
-    #PATH="/app/bin:${PATH}"
 
 ENTRYPOINT ["YACReaderLibraryServer","start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ ENV YACREADER_VERSION 9.13.1
 
 # Update system
 RUN apt-get update && \
-    apt-get -y install git \
-    build-essential p7zip-full sqlite3 libunarr-dev qtdeclarative5-dev qt5-image-formats-plugins libpoppler-qt5-dev libpoppler-qt5-1 libqt5sql5 libqt5sql5-sqlite libqt5network5 libqt5gui5 libqt5core5a
+    apt-get -y install git build-essential p7zip-full sqlite3 libunarr-dev qtdeclarative5-dev qt5-image-formats-plugins libpoppler-qt5-dev libpoppler-qt5-1 libqt5sql5 libqt5sql5-sqlite libqt5network5 libqt5gui5 libqt5core5a
 
 RUN git clone https://github.com/YACReader/yacreader.git . && \
     git checkout ${YACREADER_VERSION}
@@ -16,13 +15,7 @@ RUN git clone https://github.com/YACReader/yacreader.git . && \
 RUN cd /src/git/YACReaderLibraryServer && \
     qmake PREFIX=/app "CONFIG+=server_standalone" YACReaderLibraryServer.pro && \
     make  && \
-    make install 
-RUN cd /     && \
-    apt-get purge -y git wget build-essential && \
-    apt-get -y autoremove &&\
-    rm -rf /src && \
-    rm -rf /var/cache/apt
-
+    make install
 
 FROM debian:bullseye as runner
 
@@ -48,5 +41,6 @@ VOLUME ["/comics"]
 EXPOSE 8080
 
 ENV LC_ALL=C.UTF8
+    #PATH="/app/bin:${PATH}"
 
 ENTRYPOINT ["YACReaderLibraryServer","start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:bullseye
-MAINTAINER muallin@gmail.com
+FROM debian:bullseye as builder
+LABEL maintainer="muallin@gmail.com"
 
 WORKDIR /src/git
 
@@ -7,20 +7,39 @@ ENV YACREADER_VERSION 9.13.1
 
 # Update system
 RUN apt-get update && \
-    apt-get -y install p7zip-full git sqlite3 build-essential libunarr-dev qtdeclarative5-dev qt5-image-formats-plugins libpoppler-qt5-dev libpoppler-qt5-1 libqt5sql5 libqt5sql5-sqlite libqt5network5 libqt5gui5 libqt5core5a
+    apt-get -y install git \
+    build-essential p7zip-full sqlite3 libunarr-dev qtdeclarative5-dev qt5-image-formats-plugins libpoppler-qt5-dev libpoppler-qt5-1 libqt5sql5 libqt5sql5-sqlite libqt5network5 libqt5gui5 libqt5core5a
 
 RUN git clone https://github.com/YACReader/yacreader.git . && \
     git checkout ${YACREADER_VERSION}
 
 RUN cd /src/git/YACReaderLibraryServer && \
-    qmake "CONFIG+=server_standalone" YACReaderLibraryServer.pro && \
+    qmake PREFIX=/app "CONFIG+=server_standalone" YACReaderLibraryServer.pro && \
     make  && \
-    make install
+    make install 
 RUN cd /     && \
     apt-get purge -y git wget build-essential && \
     apt-get -y autoremove &&\
     rm -rf /src && \
     rm -rf /var/cache/apt
+
+
+FROM debian:bullseye as runner
+
+RUN apt-get update && \
+    apt-get -y install p7zip-full \
+    sqlite3 \
+    libunarr-dev \
+    qt5-image-formats-plugins \
+    libpoppler-qt5-1 \
+    libqt5sql5 \
+    libqt5sql5-sqlite \
+    libqt5network5 \
+    libqt5gui5 \
+    libqt5core5a
+
+COPY --from=builder --chown=root:root /app /usr
+
 ADD YACReaderLibrary.ini /root/.local/share/YACReader/YACReaderLibrary/
 
 # add specific volumes: configuration, comics repository, and hidden library data to separate them


### PR DESCRIPTION
added builder stage to dockerfile
removed the rm -rf and package purge code for builder stage as it is no longer needed
changed MAINTAINER to LABEL maintainer= (this is preferred from now i guess)
changed output of qmake etc to /app
added runner stage to dockerfile
limited runner stage to the packages needed to run
copied /app from builder to /usr in runner